### PR TITLE
fix: rewrite UDP forwarding and add CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,17 +2,22 @@ name: ci
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  build:
+  go-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-      - run: go build main.go
+      - uses: robherley/go-test-action@42a1975c97156330b5126c2f35ef0fb78c4c7154 # v0.7.1

--- a/endpoint/listener.go
+++ b/endpoint/listener.go
@@ -3,7 +3,6 @@ package endpoint
 import (
 	"crypto/tls"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -82,57 +81,74 @@ func (l *Listener) startUDP(ip string, srv *tsnet.Server) {
 
 		go func(c net.Conn) {
 			defer c.Close()
-
 			packet := c.(nettype.ConnPacketConn)
-			buf := make([]byte, 1500)
-
-			for {
-				n, _, err := packet.ReadFrom(buf)
-				if err != nil {
-					log.Print(err)
-					return
-				}
-
-				if n == 0 {
-					continue
-				}
-
-				remoteAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", ip, l.Port))
-				if err != nil {
-					log.Print(err)
-					return
-				}
-
-				remoteConn, err := net.DialUDP("udp", nil, remoteAddr)
-				if err != nil {
-					log.Print(err)
-					return
-				}
-				defer remoteConn.Close()
-
-				_, err = remoteConn.Write(buf[:n])
-				if err != nil {
-					log.Print(err)
-					return
-				}
-
-				var wg sync.WaitGroup
-				wg.Add(2)
-
-				go func() {
-					defer wg.Done()
-					io.Copy(remoteConn, packet)
-				}()
-
-				go func() {
-					defer wg.Done()
-					io.Copy(packet, remoteConn)
-				}()
-
-				wg.Wait()
+			if err := forwardUDP(packet, fmt.Sprintf("%s:%d", ip, l.Port)); err != nil {
+				log.Print(err)
 			}
 		}(conn)
 	}
+}
+
+// forwardUDP proxies UDP traffic bidirectionally between a tailscale
+// PacketConn and a remote target address.
+func forwardUDP(packet nettype.ConnPacketConn, targetAddr string) error {
+	remoteAddr, err := net.ResolveUDPAddr("udp", targetAddr)
+	if err != nil {
+		return err
+	}
+
+	remoteConn, err := net.DialUDP("udp", nil, remoteAddr)
+	if err != nil {
+		return err
+	}
+	defer remoteConn.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// When one direction fails, close both connections to unblock the other.
+	closeOnce := sync.OnceFunc(func() {
+		packet.Close()
+		remoteConn.Close()
+	})
+
+	// Copy from tailscale client to remote target
+	go func() {
+		defer wg.Done()
+		defer closeOnce()
+		buf := make([]byte, 65535)
+		for {
+			n, _, err := packet.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			if n == 0 {
+				continue
+			}
+			if _, err := remoteConn.Write(buf[:n]); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Copy from remote target back to tailscale client
+	go func() {
+		defer wg.Done()
+		defer closeOnce()
+		buf := make([]byte, 65535)
+		for {
+			n, _, err := remoteConn.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			if _, err := packet.WriteTo(buf[:n], packet.RemoteAddr()); err != nil {
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	return nil
 }
 
 func (l *Listener) Start(ip string, srv *tsnet.Server) {

--- a/endpoint/listener_test.go
+++ b/endpoint/listener_test.go
@@ -1,0 +1,112 @@
+package endpoint
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// connPacketConn wraps a net.UDPConn to satisfy nettype.ConnPacketConn
+// by providing both net.Conn and net.PacketConn interfaces with a fixed
+// remote address for WriteTo responses.
+type connPacketConn struct {
+	*net.UDPConn
+	remote net.Addr
+}
+
+func (c *connPacketConn) RemoteAddr() net.Addr {
+	return c.remote
+}
+
+func TestForwardUDP(t *testing.T) {
+	// Start a UDP echo server (the "target")
+	target, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			n, addr, err := target.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			target.WriteTo(buf[:n], addr)
+		}
+	}()
+
+	// Create a UDP socket pair for the "tailscale peer" side.
+	// peerConn is what the forwarder reads/writes (simulates tsnet's ConnPacketConn).
+	// clientConn is what the test sends/receives on (simulates the tailscale peer).
+	peerListener, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer peerListener.Close()
+
+	clientConn, err := net.DialUDP("udp", nil, peerListener.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+
+	// Send a discovery packet so peerListener knows the client's address
+	_, err = clientConn.Write([]byte("init"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 65535)
+	n, clientAddr, err := peerListener.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "init" {
+		t.Fatalf("expected init, got %q", string(buf[:n]))
+	}
+
+	// Wrap peerListener as a ConnPacketConn
+	peerUDP := peerListener.(*net.UDPConn)
+	cpc := &connPacketConn{UDPConn: peerUDP, remote: clientAddr}
+
+	// Run the forwarder in a goroutine
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- forwardUDP(cpc, target.LocalAddr().String())
+	}()
+
+	// Test: send data from client → should be echoed back via forwarder → target → forwarder → client
+	testMessages := []string{"hello", "world", "udp forwarding works!"}
+	for _, msg := range testMessages {
+		_, err = clientConn.Write([]byte(msg))
+		if err != nil {
+			t.Fatalf("write %q: %v", msg, err)
+		}
+
+		clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, err = clientConn.Read(buf)
+		if err != nil {
+			t.Fatalf("read echo for %q: %v", msg, err)
+		}
+
+		if got := string(buf[:n]); got != msg {
+			t.Errorf("expected %q, got %q", msg, got)
+		}
+	}
+
+	// Clean shutdown: close the peer conn to simulate session end.
+	// UDP is connectionless so closing clientConn doesn't signal peerUDP.
+	// In production, tsnet closes the conn when the session expires.
+	peerUDP.Close()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Logf("forwardUDP returned (expected after close): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("forwardUDP did not return after peer close")
+	}
+}


### PR DESCRIPTION
## Changes

### UDP forwarding fixes
- Extract `forwardUDP` as a standalone testable function
- Fix connection leak: single `DialUDP` per session instead of per-packet
- Fix defer accumulation: `defer` at function scope, not inside loop
- Fix stuck goroutines: `sync.OnceFunc` closes both connections when either direction fails
- Use 65535-byte buffers (max UDP) instead of 1500 (MTU-limited)

### Testing
- Add `TestForwardUDP` with localhost UDP echo server validating bidirectional forwarding and clean shutdown

### CI
- Replace `go build main.go` with `robherley/go-test-action` (covers build + test with PR annotations)
- Add concurrency control and `workflow_dispatch` trigger